### PR TITLE
Refactored to be POSIX-compliant + a few fixes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 2. Run this script
 
 ```
-$ curl -OL https://raw.githubusercontent.com/U2FsdGVkX1/vps2suse/main/vps2suse # or use https://cdn.jsdelivr.net/gh/U2FsdGVkX1/vps2suse@main/vps2suse
+$ curl -OL https://git.io/vps2suse # or use https://cdn.jsdelivr.net/gh/U2FsdGVkX1/vps2suse@main/vps2suse
 $ chmod +x vps2suse
 $ sudo ./vps2suse #[OPTIONS]
 ```
@@ -40,6 +40,13 @@ passwd
 -s Set OS version, For example "-s Leap-15.3" (Default: Tumbleweed).
 -c Set architecture type for the container image (Default: auto detect).
 -m Set mirror address (Default: https://download.opensuse.org).
+```
+
+## Notes
+
+The script adds a systemd unit to copy the route to gateway by default. It can be disabled using
+```
+sudo systemctl disable setup-gateway.service
 ```
 
 ## Credits

--- a/vps2suse
+++ b/vps2suse
@@ -17,42 +17,41 @@
 
 set -e
 
-[ $EUID -ne 0 ] && echo "This script must be run as root" && exit 1
+[ "$(id -u)" -ne 0 ] && echo "This script must be run as root" && exit 1
 
 if command -v wget >/dev/null 2>&1; then
-	download() { wget -O- "$mirror/$@" || wget -O- "http://download.opensuse.org/$@"; }
+	download() { wget -O- "$mirror/$*" || wget -O- "http://download.opensuse.org/$*"; }
 elif command -v curl >/dev/null 2>&1; then
-	download() { curl -fL "$mirror/$@" || curl -fL "http://download.opensuse.org/$@"; }
+	download() { curl -fL "$mirror/$*" || curl -fL "http://download.opensuse.org/$*"; }
 else
 	echo "This script needs curl or wget" >&2
 	exit 2
 fi
 
 download_and_extract_bootstrap() {
-	local sha256 filename
-
 	download "repositories/Virtualization:/containers:/images:/openSUSE-$version/$container/opensuse-$versionlower-image.$cpu_type-lxc.tar.xz.sha256" > sha256sums.txt
-	read -r sha256 filename < sha256sums.txt
-	download "repositories/Virtualization:/containers:/images:/openSUSE-$version/$container/$filename" > $filename
+	filename=$(awk '{print $2}' sha256sums.txt)
+	download "repositories/Virtualization:/containers:/images:/openSUSE-$version/$container/$filename" > "$filename"
 	sha256sum -c sha256sums.txt || exit 1
 
 	mkdir openSUSE
-	tar -xpf $filename -C /openSUSE
-	rm -f $filename
+	tar -xpf "$filename" -C /openSUSE
+	rm -f "$filename"
 
 	if grep -E "^nameserver\s+127\." /etc/resolv.conf > /dev/null; then
 		echo "nameserver 8.8.8.8" > /openSUSE/etc/resolv.conf
 	else
 		cp -Lp /etc/resolv.conf /openSUSE/etc
 	fi
-	find /openSUSE/etc/zypp/repos.d -name "*oss.repo" | xargs sed -i "s#http://download.opensuse.org#$mirror#g"
-	ld=`find /openSUSE/lib/ /openSUSE/lib64/ -name "ld-linux*.so*" -print -quit`
+	find /openSUSE/etc/zypp/repos.d -name "*oss.repo" -print0 | xargs -0 sed -i "s#http://download.opensuse.org#$mirror#g"
+	ld=$(find /openSUSE/lib/ /openSUSE/lib64/ -name "ld-linux*.so*" -print -quit)
 
 	mount -t proc /proc /openSUSE/proc
 	mount --make-rslave --rbind /sys /openSUSE/sys
 	mount --make-rslave --rbind /dev /openSUSE/dev
 	mount --make-rslave --rbind /run /openSUSE/run
 	mount --bind / /openSUSE/mnt
+	unset filename
 }
 
 save_root_pass() {
@@ -88,16 +87,18 @@ configure_chroot() {
 }
 
 install_packages() {
-	local patterns="enhanced_base bootloader yast2_basis yast2_server"
-	local packages="wicked kernel-default scout lvm2 man iptables iputils"
+	patterns="enhanced_base bootloader yast2_basis yast2_server"
+	packages="wicked kernel-default scout lvm2 man iptables iputils"
 	chroot_exec "zypper -i --root=/mnt in -y -t pattern $patterns"
 	/usr/sbin/update-ca-certificates
+	# Here we actually want the words to split, therefore no quotes.
 	zypper in -y $packages
+	unset patterns packages
 }
 
 restore_root_pass() {
 	# If the root password is not set, use vps2suse
-	if egrep -q '^root:.?:' /openSUSE/root.passwd; then
+	if grep -E -q '^root:.?:' /openSUSE/root.passwd; then
 		echo "root:vps2suse" | chpasswd
 	else
 		sed -i '/^root:/d' /etc/shadow
@@ -124,13 +125,13 @@ configure_bootloader() {
 	
 	systemd-machine-id-setup && dracut -f --regenerate-all
 	if [ -d /sys/firmware/efi ]; then
-		local efi_directory=$(df --type=vfat | tail -n1 | awk '{print $6}')
-		/usr/sbin/grub2-install --recheck --removable --efi-directory=$efi_directory
+		efi_directory=$(df --type=vfat | tail -n1 | awk '{print $6}')
+		/usr/sbin/grub2-install --recheck --removable --efi-directory="$efi_directory"
 		cat > /etc/sysconfig/bootloader <<-EOF
 			LOADER_TYPE="grub2-efi"
 		EOF
 	else
-		local root_dev=$(findmnt -no SOURCE /)
+		root_dev=$(findmnt -no SOURCE /)
 		root_dev=$(lsblk -npsro TYPE,NAME "$root_dev" | awk '$1 == "disk" {print $2}' | head -1)
 		/usr/sbin/grub2-install --recheck --force "$root_dev"
 		cat > /etc/sysconfig/bootloader <<-EOF
@@ -138,13 +139,14 @@ configure_bootloader() {
 		EOF
 	fi
 	/sbin/update-bootloader
+	unset efi_directory root_dev
 }
 
 configure_network() {
 	for dev in $(ip -br l | awk '$2 == "UP" {split($1, r, "@"); print r[1]}'); do
-		local ip="$(ip -br a s $dev scope global | awk '{for(i=3;i<=NF;i++) printf "IPADDR%d=%s\n", i-3, $i}')"
-		local routes="$(ip -4 r s default; ip -6 r s default)"
-		local gateway="$(echo "$routes" | awk -v dev=$dev '$5 == dev {printf "default %s\n", $3}')"
+		ip="$(ip -br a s "$dev" scope global | awk '{for(i=3;i<=NF;i++) printf "IPADDR%d=%s\n", i-3, $i}')"
+		routes="$(ip -4 r s default; ip -6 r s default)"
+		gateway="$(echo "$routes" | awk -v dev="$dev" '$5 == dev {printf "default %s\n", $3}')"
 
 		cat > "/etc/sysconfig/network/ifcfg-$dev" <<-EOF
 			STARTMODE=auto
@@ -154,12 +156,60 @@ configure_network() {
 			$gateway
 		EOF
 	done
+	unset dev ip routes gateway
+}
+
+setup_gateway_systemd_unit() {
+	# Creates a systemd unit to persist a gateway ipv4 rule like:
+	# default via xxx.xxx.xxx.xxx dev eth0
+	if [ "$(ip -4 r | grep 'default via')" = "" ]; then 
+		echo "No 'default via' rules found, skipping systemd unit setup."
+		return
+	fi
+	gateway_route=$(ip -4 r | grep 'default via')
+	script_dir="/root/.scripts"
+	script_path="$script_dir/gateway-default.sh"
+	systemd_unit_name="setup-gateway.service"
+	systemd_unit_path="/etc/systemd/system/$systemd_unit_name"
+	mkdir -p $script_dir
+	cat > $script_path <<-EOF
+		#!/usr/bin/env bash
+
+		ip route add $gateway_route
+	EOF
+	chmod 700 $script_path
+	cat > $systemd_unit_path <<-EOF
+		[Unit]
+		Description=Add static routes after network up
+		After=network.target
+
+		[Service]
+		ExecStart=/usr/bin/bash $script_path
+		Type=oneshot
+
+		[Install]
+		WantedBy=network.target
+	EOF
+	systemctl enable $systemd_unit_name
+	if [ "$(systemctl is-enabled $systemd_unit_name)" = "enabled" ]; then 
+	    echo "Gateway default route unit setup complete, check $script_path just in case for anything broken."
+	else
+		echo "Got an error trying to set up systemd gateway unit, might need to check it manually."
+	fi
+	unset gateway_route script_dir script_path systemd_unit_name systemd_unit_path
 }
 
 finalize() {
-	cat > "/etc/ssh/sshd_config.d/PermitRootLogin.conf" <<-EOF
-		PermitRootLogin yes
-	EOF
+	if [ -d "sshd_config.d" ]; then
+		cat > "/etc/ssh/sshd_config.d/PermitRootLogin.conf" <<-EOF
+			PermitRootLogin yes
+		EOF
+	elif [ "$(grep -w "^PermitRootLogin yes" /etc/ssh/sshd_config)" = "" ]; then
+		mkdir -p /etc/ssh/sshd_config.d
+		cat > "/etc/ssh/sshd_config.d/PermitRootLogin.conf" <<-EOF
+			PermitRootLogin yes
+		EOF
+	fi
 	systemctl enable sshd
 
 	cat <<-EOF
@@ -178,7 +228,7 @@ version=Tumbleweed
 mirror=http://download.opensuse.org
 container=container
 ld=
-if [ $cpu_type = aarch64 ]; then
+if [ "$cpu_type" = aarch64 ]; then
 	container='container_ARM'
 fi
 
@@ -186,6 +236,15 @@ while getopts "s:c:m:h:" opt; do
 	case $opt in
 	s)
 		version="$OPTARG"
+		case $version in
+		*Leap-15.4|*Leap-15.5|*Leap-15.6)
+			echo "Leap distributions above 15.3 are currently not supported. You can try installing 15.3 and upgrading manually afterwards."
+			exit 1
+			;;
+		*Leap*) 
+			# Fixes URI for the leap distribution.
+			container="containers" ;;
+		esac
 		;;
 	c)
 		container="$OPTARG"
@@ -216,7 +275,7 @@ while getopts "s:c:m:h:" opt; do
 	esac
 done
 shift $((OPTIND - 1))
-versionlower=$(echo $version | awk -F- '{print tolower($1)}')
+versionlower=$(echo "$version" | awk -F- '{print tolower($1)}')
 
 cd /
 download_and_extract_bootstrap
@@ -229,4 +288,5 @@ restore_root_pass
 cleanup
 configure_bootloader
 configure_network
+setup_gateway_systemd_unit
 finalize


### PR DESCRIPTION
Tested a few runs - both Leap and Tumbleweed seem to be installing fine. Added a systemd unit to copy a default ip route from the previous OS. Refactored code to make it POSIX-compliant, removed bashisms, it shouldn't run into errors on systems with sh symlinked to dash anymore (for example on Ubuntu).

Added a check for Leap distos to fix the URI.

Also made a restriction for Leap 15.4, 15.5, 15.6 - current path doesn't have repos for 15.4 and up.